### PR TITLE
Bump icon versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ You can find all code reference in the docs of the icon packs bellow.
 
 | Icon pack | Icon Version | Dependency | All Icons Docs |
 | --- | --- | --- | --- |
-| [Simple-Icons](https://simpleicons.org/) | 4.14.0 | `simple-icons` | [docs](simple-icons/DOCUMENTATION.md) |
-| [Feather](https://feathericons.com/) | 4.28.0 | `feather` | [docs](feather/DOCUMENTATION.md) |
-| [Tabler Icons](https://tabler-icons.io/) | 1.39.1 | `tabler-icons` | [docs](tabler-icons/DOCUMENTATION.md) |
-| [Eva Icons](https://akveo.github.io/eva-icons/#/) | 1.1.3 | `eva-icons` | [docs](eva-icons/DOCUMENTATION.md) |
-| [Font Awesome](https://fontawesome.com/) | 5.15.2 | `font-awesome` | [docs](font-awesome/DOCUMENTATION.md) |
-| [Octicons](https://primer.style/octicons/) | 12.1.0 | `octicons` | [docs](octicons/DOCUMENTATION.md) |
-| [Linea](http://www.linea.io/) | 1.0 | `linea` | [docs](linea/DOCUMENTATION.md) |
-| [Line Awesome](https://icons8.com/line-awesome) | 1.3.0 (a60f113) | `line-awesome` | [docs](line-awesome/DOCUMENTATION.md) |
-| [Weather Icons by Erik Flowers](https://github.com/erikflowers/weather-icons) | 2.0.12 | `erikflowers-weather-icons` | [docs](erikflowers-weather-icons/DOCUMENTATION.md) |
-| [css.gg](https://css.gg/) | 2.0.0 | `css-gg` | [docs](css-gg/DOCUMENTATION.md) |
+| [css.gg](https://css.gg) | 2.1.1 | `css-gg` | [docs](css-gg/DOCUMENTATION.md) |
+| [Erik Flowers' Weather Icons](https://github.com/erikflowers/weather-icons) | 2.0.12 | `erikflowers-weather-icons` | [docs](erikflowers-weather-icons/DOCUMENTATION.md) |
+| [Eva Icons](https://akveo.github.io/eva-icons) | 1.1.3 | `eva-icons` | [docs](eva-icons/DOCUMENTATION.md) |
+| [Feather](https://feathericons.com) | 4.29.2 | `feather` | [docs](feather/DOCUMENTATION.md) |
+| [Font Awesome](https://fontawesome.com) | 6.6.0 | `font-awesome` | [docs](font-awesome/DOCUMENTATION.md) |
+| [Line Awesome](https://icons8.com/line-awesome) | 1.3.1 (78a1012) | `line-awesome` | [docs](line-awesome/DOCUMENTATION.md) |
+| [Linea](https://github.com/linea-io/Linea-Iconset) | 1.0 | `linea` | [docs](linea/DOCUMENTATION.md) |
+| [Octicons](https://primer.style/octicons) | 19.12.0 | `octicons` | [docs](octicons/DOCUMENTATION.md) |
+| [Simple-Icons](https://simpleicons.org) | 13.16.0 | `simple-icons` | [docs](simple-icons/DOCUMENTATION.md) |
+| [Tabler Icons](https://tabler-icons.io) | 3.22.0 | `tabler-icons` | [docs](tabler-icons/DOCUMENTATION.md) |
 
 ## Version Catalog
 

--- a/css-gg/build.gradle.kts
+++ b/css-gg/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 
 registerGeneratorTask(
     githubId = "astrit/css.gg",
-    version = "2.0.0",
+    version = "2.1.1",
     mapSourceCodeIconsToSvgComposeFolder = { repoCloneDir ->
         val iconsDir = File(repoCloneDir, "icons/svg")
 
@@ -45,6 +45,6 @@ registerGeneratorTask(
         accessorName = "CssGgIcons",
     ),
     licensePathAtRepo = { "LICENSE" },
-    documentationHeader = "[css.gg](https://css.gg/)"
+    documentationHeader = "[css.gg](https://css.gg)"
 )
 

--- a/erikflowers-weather-icons/build.gradle.kts
+++ b/erikflowers-weather-icons/build.gradle.kts
@@ -45,6 +45,6 @@ registerGeneratorTask(
         accessorName = "WeatherIcons",
     ),
     licensePathAtRepo = { null },
-    documentationHeader = "[Weather Icons by Erik Flowers](https://github.com/erikflowers/weather-icons)",
+    documentationHeader = "[Erik Flowers' Weather Icons](https://github.com/erikflowers/weather-icons)",
     licenseUrl = { _, _ -> "http://scripts.sil.org/OFL" }
 )

--- a/erikflowers-weather-icons/gradle.properties
+++ b/erikflowers-weather-icons/gradle.properties
@@ -1,2 +1,2 @@
-POM_NAME=Compose Icons Weather Icons by Erik Flowers
+POM_NAME=Compose Icons Erik Flowers' Weather Icons
 POM_ARTIFACT_ID=erikflowers-weather-icons

--- a/eva-icons/build.gradle.kts
+++ b/eva-icons/build.gradle.kts
@@ -71,5 +71,5 @@ registerGeneratorTask(
         }
     ),
     licensePathAtRepo = { "LICENSE.txt" },
-    documentationHeader = "[Eva Icons](https://akveo.github.io/eva-icons/)",
+    documentationHeader = "[Eva Icons](https://akveo.github.io/eva-icons)",
 )

--- a/feather/build.gradle.kts
+++ b/feather/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 
 registerGeneratorTask(
     githubId = "feathericons/feather",
-    version = "v4.28.0",
+    version = "v4.29.2",
     mapSourceCodeIconsToSvgComposeFolder = { repoCloneDir ->
         val iconsDir = File(repoCloneDir, "icons")
 
@@ -46,5 +46,5 @@ registerGeneratorTask(
         accessorName = "FeatherIcons",
     ),
     licensePathAtRepo = { "LICENSE" },
-    documentationHeader = "[Feather Icons](https://feathericons.com/)"
+    documentationHeader = "[Feather Icons](https://feathericons.com)"
 )

--- a/font-awesome/build.gradle.kts
+++ b/font-awesome/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 
 registerGeneratorTask(
     githubId = "FortAwesome/Font-Awesome",
-    version = "5.15.2",
+    version = "6.6.0",
     mapSourceCodeIconsToSvgComposeFolder = { repoCloneDir ->
         val relocatedNames = mutableMapOf<String, String>()
 

--- a/line-awesome/build.gradle.kts
+++ b/line-awesome/build.gradle.kts
@@ -18,8 +18,8 @@ android {
 
 registerGeneratorTask(
     githubId = "icons8/line-awesome",
-    version = "a60f11367584e7df157277b5ab9d1654ec91ae24",
-    gitCheckoutName = "a60f11367584e7df157277b5ab9d1654ec91ae24",
+    version = "78a101217707c9b1c4dcf2a821be75684e36307f", // 1.3.1
+    gitCheckoutName = "78a101217707c9b1c4dcf2a821be75684e36307f",
     mapSourceCodeIconsToSvgComposeFolder = { repoCloneDir ->
         val relocatedNames = mutableMapOf<String, String>()
 

--- a/linea/build.gradle.kts
+++ b/linea/build.gradle.kts
@@ -61,5 +61,5 @@ registerGeneratorTask(
         accessorName = "LineaIcons",
     ),
     licensePathAtRepo = { "LICENSE" },
-    documentationHeader = "[Linea](http://www.linea.io/)"
+    documentationHeader = "[Linea](https://github.com/linea-io/Linea-Iconset)"
 )

--- a/octicons/build.gradle.kts
+++ b/octicons/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 
 registerGeneratorTask(
     githubId = "primer/octicons",
-    version = "v12.1.0",
+    version = "v19.12.0",
     mapSourceCodeIconsToSvgComposeFolder = { repoCloneDir ->
         val relocatedNames = mutableMapOf<String, String>()
 
@@ -46,5 +46,5 @@ registerGeneratorTask(
         accessorName = "Octicons",
     ),
     licensePathAtRepo = { "LICENSE" },
-    documentationHeader = "[Octicons](https://primer.style/octicons/)"
+    documentationHeader = "[Octicons](https://primer.style/octicons)"
 )

--- a/sample/src/commonMain/kotlin/compose/icons/sample/data/iconPacks.kt
+++ b/sample/src/commonMain/kotlin/compose/icons/sample/data/iconPacks.kt
@@ -1,6 +1,5 @@
 package compose.icons.sample.data
 
-import compose.icons.AllIcons
 import compose.icons.AllIconsNamed
 import compose.icons.CssGgIcons
 import compose.icons.EvaIcons
@@ -21,7 +20,7 @@ val iconPacks = listOf(
         allIcons = CssGgIcons.AllIconsNamed,
     ),
     IconPackModel(
-        packName = "Weather Icons by Erik Flowers",
+        packName = "Erik Flowers' Weather Icons",
         allIcons = WeatherIcons.AllIconsNamed,
     ),
     IconPackModel(

--- a/tabler-icons/build.gradle.kts
+++ b/tabler-icons/build.gradle.kts
@@ -18,23 +18,24 @@ android {
 
 registerGeneratorTask(
     githubId = "tabler/tabler-icons",
-    version = "v1.39.1",
+    version = "v3.22.0",
     mapSourceCodeIconsToSvgComposeFolder = { repoCloneDir ->
-        val iconsDir = File(repoCloneDir, "icons")
-
         val relocatedNames = mutableMapOf<String, String>()
 
-        // renaming to match to svg-to-compose
-        iconsDir.listFiles().filter { it.extension == "svg" }
-            .forEach {
-                val newFile = File(it.parentFile, it.name.replace("-", "_"))
+        val iconsDir = File(repoCloneDir, "icons")
+        val iconFiles = iconsDir.listFiles()
+            ?.flatMap { it.listFiles().orEmpty().toList() }
+            ?.filter { it.extension == "svg" }
+            .orEmpty()
+        iconFiles.forEach {
+            val newFile = File(it.parentFile, it.name.replace("-", "_"))
 
-                // store the name change
-                relocatedNames.putRelocatedRelativeTo(repoCloneDir, newFile, it)
+            // store the name change
+            relocatedNames.putRelocatedRelativeTo(repoCloneDir, newFile, it)
 
-                // rename to conform with SVG to Compose
-                it.renameTo(newFile)
-            }
+            // rename to conform with SVG to Compose
+            it.renameTo(newFile)
+        }
 
         MapIconsToSvgComposeFolderResult(
             iconsFolder = iconsDir,


### PR DESCRIPTION
Additionally:
- Changed name of "Weather Icons by Erik Flowers" to "Erik Flowers' Weather Icons"
- Changed Linea domain to GitHub repository as it is owned by a 3rd party now 
- Rearranged the icon set in README.md alphabetically

Lemme know if the changes are fine and I'll push the generated icons

Supersedes #30

Version bumps: 
| Icon pack    | Old version     | New Version     |
|--------------|-----------------|-----------------|
| css.gg       | 2.0.0           | 2.1.1           |
| Feather      | 4.28.0          | 4.29.2          |
| Font Awesome | 5.15.2          | 6.6.0           |
| Line Awesome | 1.2.1 (a60f113) | 1.3.1 (78a1012) |
| Octicons     | 12.1.0          | 19.12.0         |
| Simple-Icons | 4.14.0          | 13.16.0         |
| Tabler Icons | 1.39.1          | 3.22.0          |

And a shameless @DevSrSouza 

Closes #25
Closes #28
Closes #32